### PR TITLE
Bugfix for divide by zero crash

### DIFF
--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -173,9 +173,9 @@ public class HotbarViewWidget {
             if (f > 0.0F) {
                 float g = 1.0F + f / 5.0F;
                 guiGraphics.pose().pushPose();
-                guiGraphics.pose().translate((float) (x + 8), (float) (y + 12), 0);
-                guiGraphics.pose().scale(1.0F / g, (g + 1.0F) / 2.0F, 0);
-                guiGraphics.pose().translate((float) (-(x + 8)), (float) (-(y + 12)), 0);
+                guiGraphics.pose().translate((float) (x + 8), (float) (y + 12), 0.0F);
+                guiGraphics.pose().scale(1.0F / g, (g + 1.0F) / 2.0F, 1.0F);
+                guiGraphics.pose().translate((float) (-(x + 8)), (float) (-(y + 12)), 0.0F);
             }
 
             guiGraphics.renderItem(player, itemStack, x, y, seed);

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -7,7 +7,6 @@ import ing.boykiss.inventoryoverhaul.imixin.IMixinInventory;
 import ing.boykiss.inventoryoverhaul.inventory.Hotbar;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -80,7 +79,7 @@ public class HotbarViewWidget {
                 guiGraphics.pose().pushPose();
                 guiGraphics.pose().translate(posX, posY, 0);
 
-                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_SLOT_SPRITE, 0, 0, 20, 20);
+                guiGraphics.blitSprite(HOTBAR_SLOT_SPRITE, 0, 0, 20, 20);
 
                 renderItemSlot(guiGraphics, 2, 2, partialTick, player, player.getInventory().getItem(itemIndex), itemIndex + 1);
 
@@ -115,7 +114,7 @@ public class HotbarViewWidget {
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0, 0, 0);
 
-        int selectedSlot = player.getInventory().getSelectedSlot();
+        int selectedSlot = player.getInventory().selected;
         int selectedX = selectedSlot % hotbar.getSizeX();
         int selectedY = selectedSlot / hotbar.getSizeX();
 
@@ -123,7 +122,7 @@ public class HotbarViewWidget {
         int selectedPosY = selectedY * 20;
 
         guiGraphics.blitSprite(
-                RenderType::guiTextured, HOTBAR_SELECTION_SPRITE, selectedPosX, selectedPosY, 22, 22
+                HOTBAR_SELECTION_SPRITE, selectedPosX, selectedPosY, 22, 22
         );
 
         guiGraphics.pose().popPose();
@@ -135,7 +134,7 @@ public class HotbarViewWidget {
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(-1, -1, 0);
 
-        int selectedSlot = player.getInventory().getSelectedSlot();
+        int selectedSlot = player.getInventory().selected;
         int selectedX = selectedSlot % hotbar.getSizeX();
         int selectedY = selectedSlot / hotbar.getSizeX();
 

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -7,7 +7,7 @@ import ing.boykiss.inventoryoverhaul.imixin.IMixinInventory;
 import ing.boykiss.inventoryoverhaul.inventory.Hotbar;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
@@ -50,25 +50,25 @@ public class HotbarViewWidget {
     public void render(GuiGraphics guiGraphics, float partialTick, Player player) {
         Hotbar hotbar = getHotbar(player);
 
-        guiGraphics.pose().pushMatrix();
+        guiGraphics.pose().pushPose();
 
         Vec2 hotbarPosition = calculatePosition(clientConfig, hotbar);
-        guiGraphics.pose().translate(hotbarPosition.x, hotbarPosition.y);
-        guiGraphics.pose().scale((float) clientConfig.getHotbarScale(), (float) clientConfig.getHotbarScale());
+        guiGraphics.pose().translate(hotbarPosition.x, hotbarPosition.y, 90);
+        guiGraphics.pose().scale((float) clientConfig.getHotbarScale(), (float) clientConfig.getHotbarScale(), (float) clientConfig.getHotbarScale());
 
         renderSlots(guiGraphics, partialTick, player);
         renderOutline(guiGraphics, player);
         renderSlotSelection(guiGraphics, player);
         renderSlotSelectionOutline(guiGraphics, player);
 
-        guiGraphics.pose().popMatrix();
+        guiGraphics.pose().popPose();
     }
 
     private void renderSlots(GuiGraphics guiGraphics, float partialTick, Player player) {
         Hotbar hotbar = getHotbar(player);
 
-        guiGraphics.pose().pushMatrix();
-        guiGraphics.pose().translate(1, 1);
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(1, 1, 0);
 
         for (int slotY = 0; slotY < hotbar.getSizeY(); slotY++) {
             for (int slotX = 0; slotX < hotbar.getSizeX(); slotX++) {
@@ -77,25 +77,25 @@ public class HotbarViewWidget {
                 int posX = slotX * 20;
                 int posY = slotY * 20;
 
-                guiGraphics.pose().pushMatrix();
-                guiGraphics.pose().translate(posX, posY);
+                guiGraphics.pose().pushPose();
+                guiGraphics.pose().translate(posX, posY, 0);
 
-                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, HOTBAR_SLOT_SPRITE, 0, 0, 20, 20);
+                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_SLOT_SPRITE, 0, 0, 20, 20);
 
                 renderItemSlot(guiGraphics, 2, 2, partialTick, player, player.getInventory().getItem(itemIndex), itemIndex + 1);
 
-                guiGraphics.pose().popMatrix();
+                guiGraphics.pose().popPose();
             }
         }
 
-        guiGraphics.pose().popMatrix();
+        guiGraphics.pose().popPose();
     }
 
     private void renderOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
 
-        guiGraphics.pose().pushMatrix();
-        guiGraphics.pose().translate(0, 0);
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(0, 0, 0);
 
         int hotbarX = hotbar.getSizeX();
         int hotbarY = hotbar.getSizeY();
@@ -106,14 +106,14 @@ public class HotbarViewWidget {
         guiGraphics.fill(0, 0, 1, 1 + hotbarY * 20, 0xFF000000);
         guiGraphics.fill(hotbarX * 20, 0, 1 + hotbarX * 20, 1 + hotbarY * 20, 0xFF000000);
 
-        guiGraphics.pose().popMatrix();
+        guiGraphics.pose().popPose();
     }
 
     private void renderSlotSelection(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
 
-        guiGraphics.pose().pushMatrix();
-        guiGraphics.pose().translate(0, 0);
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(0, 0, 0);
 
         int selectedSlot = player.getInventory().getSelectedSlot();
         int selectedX = selectedSlot % hotbar.getSizeX();
@@ -123,17 +123,17 @@ public class HotbarViewWidget {
         int selectedPosY = selectedY * 20;
 
         guiGraphics.blitSprite(
-                RenderPipelines.GUI_TEXTURED, HOTBAR_SELECTION_SPRITE, selectedPosX, selectedPosY, 22, 22
+                RenderType::guiTextured, HOTBAR_SELECTION_SPRITE, selectedPosX, selectedPosY, 22, 22
         );
 
-        guiGraphics.pose().popMatrix();
+        guiGraphics.pose().popPose();
     }
 
     private void renderSlotSelectionOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
 
-        guiGraphics.pose().pushMatrix();
-        guiGraphics.pose().translate(-1, -1);
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(-1, -1, 0);
 
         int selectedSlot = player.getInventory().getSelectedSlot();
         int selectedX = selectedSlot % hotbar.getSizeX();
@@ -163,7 +163,7 @@ public class HotbarViewWidget {
             guiGraphics.fill(selectedPosX + 22, selectedPosY, endSelectedPosX + 22, endSelectedPosY + (lastY ? 22 : 23), 0xFF000000);
         }
 
-        guiGraphics.pose().popMatrix();
+        guiGraphics.pose().popPose();
     }
 
     // copied over from Gui class
@@ -172,15 +172,15 @@ public class HotbarViewWidget {
             float f = itemStack.getPopTime() - partialTick;
             if (f > 0.0F) {
                 float g = 1.0F + f / 5.0F;
-                guiGraphics.pose().pushMatrix();
-                guiGraphics.pose().translate((float) (x + 8), (float) (y + 12));
-                guiGraphics.pose().scale(1.0F / g, (g + 1.0F) / 2.0F);
-                guiGraphics.pose().translate((float) (-(x + 8)), (float) (-(y + 12)));
+                guiGraphics.pose().pushPose();
+                guiGraphics.pose().translate((float) (x + 8), (float) (y + 12), 0);
+                guiGraphics.pose().scale(1.0F / g, (g + 1.0F) / 2.0F, 0);
+                guiGraphics.pose().translate((float) (-(x + 8)), (float) (-(y + 12)), 0);
             }
 
             guiGraphics.renderItem(player, itemStack, x, y, seed);
             if (f > 0.0F) {
-                guiGraphics.pose().popMatrix();
+                guiGraphics.pose().popPose();
             }
 
             guiGraphics.renderItemDecorations(Minecraft.getInstance().font, itemStack, x, y);

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -66,6 +66,8 @@ public class HotbarViewWidget {
     private void renderSlots(GuiGraphics guiGraphics, float partialTick, Player player) {
         Hotbar hotbar = getHotbar(player);
 
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
+
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(1, 1, 0);
 
@@ -93,6 +95,8 @@ public class HotbarViewWidget {
     private void renderOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
 
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
+
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0, 0, 0);
 
@@ -110,6 +114,8 @@ public class HotbarViewWidget {
 
     private void renderSlotSelection(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
+
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
 
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0, 0, 0);
@@ -130,6 +136,8 @@ public class HotbarViewWidget {
 
     private void renderSlotSelectionOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
+
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
 
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(-1, -1, 0);

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/gamerule/HotbarSizeGameRules.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/gamerule/HotbarSizeGameRules.java
@@ -4,7 +4,6 @@ import ing.boykiss.inventoryoverhaul.InventoryOverhaul;
 import ing.boykiss.inventoryoverhaul.imixin.IMixinInventory;
 import ing.boykiss.inventoryoverhaul.mixin.InvokerIntegerValue;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.GameRules;
 
 public class HotbarSizeGameRules {
@@ -51,10 +50,10 @@ public class HotbarSizeGameRules {
         );
     }
 
-    public static final GameRules.Key<GameRules.IntegerValue> HOTBAR_SIZE_X = GameRules.register("hotbarSizeX", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(9, 1, 9, FeatureFlagSet.of(), HotbarSizeGameRules::resizeHotbarX));
+    public static final GameRules.Key<GameRules.IntegerValue> HOTBAR_SIZE_X = GameRules.register("hotbarSizeX", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(9, 1, 9, HotbarSizeGameRules::resizeHotbarX));
 
 
-    public static final GameRules.Key<GameRules.IntegerValue> HOTBAR_SIZE_Y = GameRules.register("hotbarSizeY", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(1, 1, 9, FeatureFlagSet.of(), HotbarSizeGameRules::resizeHotbarY));
+    public static final GameRules.Key<GameRules.IntegerValue> HOTBAR_SIZE_Y = GameRules.register("hotbarSizeY", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(1, 1, 9, HotbarSizeGameRules::resizeHotbarY));
 
 
 }

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/gamerule/InventorySizeGameRules.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/gamerule/InventorySizeGameRules.java
@@ -1,8 +1,8 @@
 package ing.boykiss.inventoryoverhaul.gamerule;
 
 public class InventorySizeGameRules {
-//    public static final GameRules.Key<GameRules.IntegerValue> INVENTORY_SIZE_X = GameRules.register("inventorySizeX", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(9, 1, 12, FeatureFlagSet.of(), InventorySizeGameRules::resizeInventoryX));
-//    public static final GameRules.Key<GameRules.IntegerValue> INVENTORY_SIZE_Y = GameRules.register("inventorySizeY", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(3, 1, 12, FeatureFlagSet.of(), InventorySizeGameRules::resizeInventoryY));
+//    public static final GameRules.Key<GameRules.IntegerValue> INVENTORY_SIZE_X = GameRules.register("inventorySizeX", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(9, 1, 12, InventorySizeGameRules::resizeInventoryX));
+//    public static final GameRules.Key<GameRules.IntegerValue> INVENTORY_SIZE_Y = GameRules.register("inventorySizeY", GameRules.Category.PLAYER, InvokerIntegerValue.invokeCreate(3, 1, 12, InventorySizeGameRules::resizeInventoryY));
 
     public static void init() {
     }

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/InvokerIntegerValue.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/InvokerIntegerValue.java
@@ -1,7 +1,6 @@
 package ing.boykiss.inventoryoverhaul.mixin;
 
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.flag.FeatureFlagSet;
 import net.minecraft.world.level.GameRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
@@ -12,7 +11,7 @@ import java.util.function.BiConsumer;
 public interface InvokerIntegerValue {
     @Invoker("create")
     static GameRules.Type<GameRules.IntegerValue> invokeCreate(
-            int i, int j, int k, FeatureFlagSet featureFlagSet, BiConsumer<MinecraftServer, GameRules.IntegerValue> biConsumer
+            int i, int j, int k, BiConsumer<MinecraftServer, GameRules.IntegerValue> biConsumer
     ) {
         throw new AssertionError();
     }

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/MixinInventory.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/MixinInventory.java
@@ -9,7 +9,6 @@ import ing.boykiss.inventoryoverhaul.inventory.Hotbar;
 import ing.boykiss.inventoryoverhaul.network.S2CInventorySizeUpdatePacket;
 import net.minecraft.client.Minecraft;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.EntityEquipment;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.GameRules;
@@ -29,12 +28,12 @@ public abstract class MixinInventory implements IMixinInventory {
     public Player player;
     @Unique
     public Hotbar inventoryoverhaul$hotbar;
+    @Shadow
+    public int selected;
     @Unique
     private int inventoryoverhaul$sizeX;
     @Unique
     private int inventoryoverhaul$sizeY;
-    @Shadow
-    private int selected;
 
     @Inject(method = "isHotbarSlot", at = @At("HEAD"), cancellable = true)
     private static void isHotbarSlot(int i, CallbackInfoReturnable<Boolean> cir) {
@@ -66,20 +65,20 @@ public abstract class MixinInventory implements IMixinInventory {
     }
 
     @Shadow
-    public abstract void setSelectedSlot(int i);
+    public abstract void swapPaint(double d);
 
-    @Inject(method = "setSelectedSlot", at = @At("HEAD"), cancellable = true)
-    public void setSelectedSlot(int i, CallbackInfo ci) {
-        if (!Inventory.isHotbarSlot(i)) {
-            setSelectedSlot(getSelectionSize() - 1);
+    @Inject(method = "swapPaint", at = @At("HEAD"), cancellable = true)
+    public void swapPaint(double d, CallbackInfo ci) {
+        if (!Inventory.isHotbarSlot((int) d)) {
+            swapPaint(getSelectionSize() - 1);
         } else {
-            this.selected = i;
+            this.selected = (int) d;
         }
         ci.cancel();
     }
 
     @Inject(method = "<init>", at = @At("TAIL"))
-    public void init(Player player, EntityEquipment entityEquipment, CallbackInfo ci) {
+    public void init(Player player, CallbackInfo ci) {
         this.inventoryoverhaul$hotbar = new Hotbar(player);
 
         if (!(player instanceof ServerPlayer serverPlayer)) return;

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinGui.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinGui.java
@@ -6,7 +6,6 @@ import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Player;
@@ -61,9 +60,9 @@ public abstract class MixinGui {
         int a = guiGraphics.guiWidth() / 2;
         if (!itemStack.isEmpty()) {
             if (humanoidArm == HumanoidArm.LEFT) {
-                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_OFFHAND_LEFT_SPRITE, a - 91 - 29, guiGraphics.guiHeight() - 23, 29, 24);
+                guiGraphics.blitSprite(HOTBAR_OFFHAND_LEFT_SPRITE, a - 91 - 29, guiGraphics.guiHeight() - 23, 29, 24);
             } else {
-                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_OFFHAND_RIGHT_SPRITE, a + 91, guiGraphics.guiHeight() - 23, 29, 24);
+                guiGraphics.blitSprite(HOTBAR_OFFHAND_RIGHT_SPRITE, a + 91, guiGraphics.guiHeight() - 23, 29, 24);
             }
         }
         // end vanilla
@@ -90,8 +89,8 @@ public abstract class MixinGui {
                 }
 
                 int p = (int) (f * 19.0F);
-                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_ATTACK_INDICATOR_BACKGROUND_SPRITE, o, n, 18, 18);
-                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_ATTACK_INDICATOR_PROGRESS_SPRITE, 18, 18, 0, 18 - p, o, n + 18 - p, 18, p);
+                guiGraphics.blitSprite(HOTBAR_ATTACK_INDICATOR_BACKGROUND_SPRITE, o, n, 18, 18);
+                guiGraphics.blitSprite(HOTBAR_ATTACK_INDICATOR_PROGRESS_SPRITE, 18, 18, 0, 18 - p, o, n + 18 - p, 18, p);
             }
         }
         // end vanilla

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinGui.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinGui.java
@@ -6,7 +6,7 @@ import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.client.renderer.RenderPipelines;
+import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Player;
@@ -61,9 +61,9 @@ public abstract class MixinGui {
         int a = guiGraphics.guiWidth() / 2;
         if (!itemStack.isEmpty()) {
             if (humanoidArm == HumanoidArm.LEFT) {
-                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, HOTBAR_OFFHAND_LEFT_SPRITE, a - 91 - 29, guiGraphics.guiHeight() - 23, 29, 24);
+                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_OFFHAND_LEFT_SPRITE, a - 91 - 29, guiGraphics.guiHeight() - 23, 29, 24);
             } else {
-                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, HOTBAR_OFFHAND_RIGHT_SPRITE, a + 91, guiGraphics.guiHeight() - 23, 29, 24);
+                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_OFFHAND_RIGHT_SPRITE, a + 91, guiGraphics.guiHeight() - 23, 29, 24);
             }
         }
         // end vanilla
@@ -90,8 +90,8 @@ public abstract class MixinGui {
                 }
 
                 int p = (int) (f * 19.0F);
-                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, HOTBAR_ATTACK_INDICATOR_BACKGROUND_SPRITE, o, n, 18, 18);
-                guiGraphics.blitSprite(RenderPipelines.GUI_TEXTURED, HOTBAR_ATTACK_INDICATOR_PROGRESS_SPRITE, 18, 18, 0, 18 - p, o, n + 18 - p, 18, p);
+                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_ATTACK_INDICATOR_BACKGROUND_SPRITE, o, n, 18, 18);
+                guiGraphics.blitSprite(RenderType::guiTextured, HOTBAR_ATTACK_INDICATOR_PROGRESS_SPRITE, 18, 18, 0, 18 - p, o, n + 18 - p, 18, p);
             }
         }
         // end vanilla

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinMouseHandler.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/mixin/client/MixinMouseHandler.java
@@ -1,15 +1,17 @@
 package ing.boykiss.inventoryoverhaul.mixin.client;
 
-import com.llamalad7.mixinextras.sugar.Local;
 import ing.boykiss.inventoryoverhaul.client.config.ClientConfig;
 import ing.boykiss.inventoryoverhaul.client.keybind.ModifierKeybind;
 import ing.boykiss.inventoryoverhaul.imixin.IMixinInventory;
 import ing.boykiss.inventoryoverhaul.inventory.Hotbar;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.MouseHandler;
-import net.minecraft.client.ScrollWheelHandler;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
@@ -17,8 +19,27 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MouseHandler.class)
 public class MixinMouseHandler {
-    @Inject(method = "onScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;setSelectedSlot(I)V"))
-    private void onScroll(long l, double d, double e, CallbackInfo ci, @Local int k, @Local Inventory inventory) {
+    @Shadow
+    @Final
+    private Minecraft minecraft;
+
+    @Unique
+    private static int inventoryoverhaul$getNextScrollWheelSelection(double j, int k, int l) {
+        int i = (int) Math.signum(j);
+        k -= i;
+        k = Math.max(-1, k);
+        while (k < 0) {
+            k += l;
+        }
+        while (k >= l) {
+            k -= l;
+        }
+        return k;
+    }
+
+    @Inject(method = "onScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;swapPaint(D)V"))
+    private void onScroll(long l, double d, double e, CallbackInfo ci) {
+        Inventory inventory = minecraft.player.getInventory();
         boolean modifierKeyHeld = ModifierKeybind.MODIFIER_KEYMAPPING.isDown();
 
         ClientConfig clientConfig = ClientConfig.getInstance();
@@ -30,31 +51,31 @@ public class MixinMouseHandler {
         boolean byRow = hotbarScrollDirection == ClientConfig.HotbarScrollDirection.ROW;
         if (hotbarScrollMode == ClientConfig.HotbarScrollMode.CONTINUOUS) {
             int base = byRow
-                    ? inventory.getSelectedSlot()
-                    : hotbar.getSlotIndexColumn(inventory.getSelectedSlot());
+                    ? inventory.selected
+                    : hotbar.getSlotIndexColumn(inventory.selected);
             int selectionSize = Inventory.getSelectionSize();
-            int next = ScrollWheelHandler.getNextScrollWheelSelection(k, base, selectionSize);
+            int next = inventoryoverhaul$getNextScrollWheelSelection(e, base, selectionSize);
             int slotIndex = byRow
                     ? next
                     : hotbar.getSlotIndexColumn(next);
-            inventory.setSelectedSlot(slotIndex);
+            inventory.swapPaint(slotIndex);
         } else if (hotbarScrollMode == ClientConfig.HotbarScrollMode.SPLIT) {
-            Tuple<Integer, Integer> currentXY = hotbar.getSlotXY(inventory.getSelectedSlot());
+            Tuple<Integer, Integer> currentXY = hotbar.getSlotXY(inventory.selected);
             boolean scrollByColumn = (byRow && modifierKeyHeld) || (!byRow && !modifierKeyHeld);
             int nextX = currentXY.getA();
             int nextY = currentXY.getB();
 
             if (scrollByColumn) {
-                nextY = ScrollWheelHandler.getNextScrollWheelSelection(k, currentXY.getB(), hotbar.getSizeY());
+                nextY = inventoryoverhaul$getNextScrollWheelSelection(e, currentXY.getB(), hotbar.getSizeY());
             } else {
-                nextX = ScrollWheelHandler.getNextScrollWheelSelection(k, currentXY.getA(), hotbar.getSizeX());
+                nextX = inventoryoverhaul$getNextScrollWheelSelection(e, currentXY.getA(), hotbar.getSizeX());
             }
 
-            inventory.setSelectedSlot(hotbar.getSlotIndex(nextX, nextY));
+            inventory.swapPaint(hotbar.getSlotIndex(nextX, nextY));
         }
     }
 
-    @Redirect(method = "onScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;setSelectedSlot(I)V"))
-    private void onScroll(Inventory instance, int i) {
+    @Redirect(method = "onScroll", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;swapPaint(D)V"))
+    private void onScroll(Inventory instance, double d) {
     }
 }

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/network/S2CHotbarSizeUpdatePacket.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/network/S2CHotbarSizeUpdatePacket.java
@@ -34,7 +34,7 @@ public record S2CHotbarSizeUpdatePacket(int x, int y) implements CustomPacketPay
         Inventory inventory = player.getInventory();
         ((IMixinInventory) inventory).inventoryoverhaul$getHotbar().setSize(packet.x(), packet.y(), false);
 
-        inventory.setSelectedSlot(inventory.getSelectedSlot()); // reset the slot to the last available if outside bounds after size update
+        inventory.swapPaint(inventory.selected); // reset the slot to the last available if outside bounds after size update
     }
 
     @Override

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,9 +28,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.14",
-    "minecraft": "~1.21.5",
+    "minecraft": "~1.21.1",
     "java": ">=21",
-    "architectury": ">=16.1.4",
+    "architectury": ">=13.0.8",
     "fabric-api": "*"
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,9 +28,9 @@
   ],
   "depends": {
     "fabricloader": ">=0.16.14",
-    "minecraft": "~1.21.8",
+    "minecraft": "~1.21.5",
     "java": ">=21",
-    "architectury": ">=17.0.8",
+    "architectury": ">=16.1.4",
     "fabric-api": "*"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,9 @@ maven_group=ing.boykiss
 archives_name=inventoryoverhaul
 enabled_platforms=fabric,neoforge
 # Minecraft properties
-minecraft_version=1.21.5
+minecraft_version=1.21.1
 # Dependencies
-architectury_api_version=16.1.4
+architectury_api_version=13.0.8
 fabric_loader_version=0.16.14
-fabric_api_version=0.128.1+1.21.5
-neoforge_version=21.5.89
+fabric_api_version=0.116.4+1.21.1
+neoforge_version=21.1.196

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,9 @@ maven_group=ing.boykiss
 archives_name=inventoryoverhaul
 enabled_platforms=fabric,neoforge
 # Minecraft properties
-minecraft_version=1.21.8
+minecraft_version=1.21.5
 # Dependencies
-architectury_api_version=17.0.8
+architectury_api_version=16.1.4
 fabric_loader_version=0.16.14
-fabric_api_version=0.130.0+1.21.8
-neoforge_version=21.8.23
+fabric_api_version=0.128.1+1.21.5
+neoforge_version=21.5.89

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ java_version=21
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Mod properties
-mod_version=0.0.1-alpha
+mod_version=0.0.2-alpha
 maven_group=ing.boykiss
 archives_name=inventoryoverhaul
 enabled_platforms=fabric,neoforge

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,14 +23,14 @@ side = "BOTH"
 [[dependencies.inventoryoverhaul]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.8,)"
+versionRange = "[1.21.5,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.inventoryoverhaul]]
 modId = "architectury"
 type = "required"
-versionRange = "[17.0.8,)"
+versionRange = "[16.1.4,)"
 ordering = "AFTER"
 side = "BOTH"
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -23,14 +23,14 @@ side = "BOTH"
 [[dependencies.inventoryoverhaul]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.5,)"
+versionRange = "[1.21.1,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.inventoryoverhaul]]
 modId = "architectury"
 type = "required"
-versionRange = "[16.1.4,)"
+versionRange = "[13.0.8,)"
 ordering = "AFTER"
 side = "BOTH"
 


### PR DESCRIPTION
The fix adds early-return guards to all render methods that check if hotbar.getSizeX() or hotbar.getSizeY() are <= 0. This prevents the division by zero error that occurs when the hotbar hasn't been initialized yet (both dimensions default to 0).
The crash was happening because the rendering code tried to calculate slot positions using modulo (%) and division (/) with hotbar.getSizeX() before the hotbar size was properly set.
[inventoryoverhaul-neoforge-mc1.21.1-0.0.2-alpha.jar.zip](https://github.com/user-attachments/files/25077382/inventoryoverhaul-neoforge-mc1.21.1-0.0.2-alpha.jar.zip)
