### PR TITLE
Survival support split bar and fixed config screen persistance

### DIFF
--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/config/ClientConfig.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/config/ClientConfig.java
@@ -36,6 +36,18 @@ public class ClientConfig extends AbstractClientConfig {
     @ConfigOption(size = ConfigOption.WidgetSize.FULL, slider = true, min = 0.5d, max = 2.0d, sliderStep = 0.05d)
     public double hotbarScale = 1.0d;
 
+    @ConfigOption
+    public boolean hotbarSplitRows = false;
+
+    @ConfigOption(size = ConfigOption.WidgetSize.TINY, min = 1, max = 8)
+    public int hotbarSplitAfterRow = 1;
+
+    @ConfigOption(size = ConfigOption.WidgetSize.TINY, min = 0, max = 100)
+    public int hotbarSplitGap = 40;
+
+    @ConfigOption(size = ConfigOption.WidgetSize.TINY, min = -100, max = 100)
+    public int hotbarSplitTopOffset = 0;
+
     public enum HotbarScrollDirection {
         ROW,
         COLUMN

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -66,6 +66,8 @@ public class HotbarViewWidget {
     private void renderSlots(GuiGraphics guiGraphics, float partialTick, Player player) {
         Hotbar hotbar = getHotbar(player);
 
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
+
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(1, 1, 0);
 
@@ -93,6 +95,8 @@ public class HotbarViewWidget {
     private void renderOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
 
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
+
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0, 0, 0);
 
@@ -110,6 +114,8 @@ public class HotbarViewWidget {
 
     private void renderSlotSelection(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
+
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
 
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(0, 0, 0);
@@ -130,6 +136,8 @@ public class HotbarViewWidget {
 
     private void renderSlotSelectionOutline(GuiGraphics guiGraphics, Player player) {
         Hotbar hotbar = getHotbar(player);
+
+        if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
 
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(-1, -1, 0);

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/HotbarViewWidget.java
@@ -49,21 +49,65 @@ public class HotbarViewWidget {
     public void render(GuiGraphics guiGraphics, float partialTick, Player player) {
         Hotbar hotbar = getHotbar(player);
 
+        if (clientConfig.isHotbarSplitRows() && hotbar.getSizeY() > 1) {
+            renderSplit(guiGraphics, partialTick, player, hotbar);
+        } else {
+            renderNormal(guiGraphics, partialTick, player, hotbar);
+        }
+    }
+
+    private void renderNormal(GuiGraphics guiGraphics, float partialTick, Player player, Hotbar hotbar) {
         guiGraphics.pose().pushPose();
 
         Vec2 hotbarPosition = calculatePosition(clientConfig, hotbar);
         guiGraphics.pose().translate(hotbarPosition.x, hotbarPosition.y, 90);
         guiGraphics.pose().scale((float) clientConfig.getHotbarScale(), (float) clientConfig.getHotbarScale(), (float) clientConfig.getHotbarScale());
 
-        renderSlots(guiGraphics, partialTick, player);
-        renderOutline(guiGraphics, player);
-        renderSlotSelection(guiGraphics, player);
-        renderSlotSelectionOutline(guiGraphics, player);
+        renderSlots(guiGraphics, partialTick, player, 0, hotbar.getSizeY());
+        renderOutline(guiGraphics, player, 0, hotbar.getSizeY());
+        renderSlotSelection(guiGraphics, player, 0, hotbar.getSizeY(), 0);
+        renderSlotSelectionOutline(guiGraphics, player, 0, hotbar.getSizeY(), 0);
 
         guiGraphics.pose().popPose();
     }
 
-    private void renderSlots(GuiGraphics guiGraphics, float partialTick, Player player) {
+    private void renderSplit(GuiGraphics guiGraphics, float partialTick, Player player, Hotbar hotbar) {
+        int splitAfterRow = Math.min(clientConfig.getHotbarSplitAfterRow(), hotbar.getSizeY() - 1);
+        int bottomRows = splitAfterRow;
+        int topRows = hotbar.getSizeY() - splitAfterRow;
+        float scale = (float) clientConfig.getHotbarScale();
+        int splitGap = clientConfig.getHotbarSplitGap();
+        int topOffset = clientConfig.getHotbarSplitTopOffset();
+
+        Vec2 bottomPosition = calculatePosition(clientConfig, hotbar);
+
+        // Render bottom section (rows 0 to splitAfterRow-1, from bottom of hotbar)
+        int bottomStartRow = hotbar.getSizeY() - bottomRows;
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(bottomPosition.x, bottomPosition.y + (topRows * 20 + splitGap) * scale, 90);
+        guiGraphics.pose().scale(scale, scale, scale);
+
+        renderSlots(guiGraphics, partialTick, player, bottomStartRow, hotbar.getSizeY());
+        renderOutline(guiGraphics, player, bottomStartRow, hotbar.getSizeY());
+        renderSlotSelection(guiGraphics, player, bottomStartRow, hotbar.getSizeY(), bottomStartRow);
+        renderSlotSelectionOutline(guiGraphics, player, bottomStartRow, hotbar.getSizeY(), bottomStartRow);
+
+        guiGraphics.pose().popPose();
+
+        // Render top section (rows splitAfterRow to end, rendered above the gap)
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(bottomPosition.x, bottomPosition.y + topOffset * scale, 90);
+        guiGraphics.pose().scale(scale, scale, scale);
+
+        renderSlots(guiGraphics, partialTick, player, 0, topRows);
+        renderOutline(guiGraphics, player, 0, topRows);
+        renderSlotSelection(guiGraphics, player, 0, topRows, 0);
+        renderSlotSelectionOutline(guiGraphics, player, 0, topRows, 0);
+
+        guiGraphics.pose().popPose();
+    }
+
+    private void renderSlots(GuiGraphics guiGraphics, float partialTick, Player player, int startRow, int endRow) {
         Hotbar hotbar = getHotbar(player);
 
         if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
@@ -71,12 +115,12 @@ public class HotbarViewWidget {
         guiGraphics.pose().pushPose();
         guiGraphics.pose().translate(1, 1, 0);
 
-        for (int slotY = 0; slotY < hotbar.getSizeY(); slotY++) {
+        for (int slotY = startRow; slotY < endRow; slotY++) {
             for (int slotX = 0; slotX < hotbar.getSizeX(); slotX++) {
                 int itemIndex = hotbar.getSlotIndex(slotX, slotY);
 
                 int posX = slotX * 20;
-                int posY = slotY * 20;
+                int posY = (slotY - startRow) * 20;
 
                 guiGraphics.pose().pushPose();
                 guiGraphics.pose().translate(posX, posY, 0);
@@ -92,7 +136,7 @@ public class HotbarViewWidget {
         guiGraphics.pose().popPose();
     }
 
-    private void renderOutline(GuiGraphics guiGraphics, Player player) {
+    private void renderOutline(GuiGraphics guiGraphics, Player player, int startRow, int endRow) {
         Hotbar hotbar = getHotbar(player);
 
         if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
@@ -101,31 +145,34 @@ public class HotbarViewWidget {
         guiGraphics.pose().translate(0, 0, 0);
 
         int hotbarX = hotbar.getSizeX();
-        int hotbarY = hotbar.getSizeY();
+        int rowCount = endRow - startRow;
 
         // top, bottom, left, right
         guiGraphics.fill(0, 0, 1 + hotbarX * 20, 1, 0xFF000000);
-        guiGraphics.fill(0, hotbarY * 20, 1 + hotbarX * 20, 1 + hotbarY * 20, 0xFF000000);
-        guiGraphics.fill(0, 0, 1, 1 + hotbarY * 20, 0xFF000000);
-        guiGraphics.fill(hotbarX * 20, 0, 1 + hotbarX * 20, 1 + hotbarY * 20, 0xFF000000);
+        guiGraphics.fill(0, rowCount * 20, 1 + hotbarX * 20, 1 + rowCount * 20, 0xFF000000);
+        guiGraphics.fill(0, 0, 1, 1 + rowCount * 20, 0xFF000000);
+        guiGraphics.fill(hotbarX * 20, 0, 1 + hotbarX * 20, 1 + rowCount * 20, 0xFF000000);
 
         guiGraphics.pose().popPose();
     }
 
-    private void renderSlotSelection(GuiGraphics guiGraphics, Player player) {
+    private void renderSlotSelection(GuiGraphics guiGraphics, Player player, int startRow, int endRow, int rowOffset) {
         Hotbar hotbar = getHotbar(player);
 
         if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
-
-        guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(0, 0, 0);
 
         int selectedSlot = player.getInventory().selected;
         int selectedX = selectedSlot % hotbar.getSizeX();
         int selectedY = selectedSlot / hotbar.getSizeX();
 
+        // Only render if selection is in this section
+        if (selectedY < startRow || selectedY >= endRow) return;
+
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(0, 0, 0);
+
         int selectedPosX = selectedX * 20;
-        int selectedPosY = selectedY * 20;
+        int selectedPosY = (selectedY - rowOffset) * 20;
 
         guiGraphics.blitSprite(
                 HOTBAR_SELECTION_SPRITE, selectedPosX, selectedPosY, 22, 22
@@ -134,27 +181,33 @@ public class HotbarViewWidget {
         guiGraphics.pose().popPose();
     }
 
-    private void renderSlotSelectionOutline(GuiGraphics guiGraphics, Player player) {
+    private void renderSlotSelectionOutline(GuiGraphics guiGraphics, Player player, int startRow, int endRow, int rowOffset) {
         Hotbar hotbar = getHotbar(player);
 
         if (hotbar.getSizeX() <= 0 || hotbar.getSizeY() <= 0) return;
-
-        guiGraphics.pose().pushPose();
-        guiGraphics.pose().translate(-1, -1, 0);
 
         int selectedSlot = player.getInventory().selected;
         int selectedX = selectedSlot % hotbar.getSizeX();
         int selectedY = selectedSlot / hotbar.getSizeX();
 
+        // Only render if selection is in this section
+        if (selectedY < startRow || selectedY >= endRow) return;
+
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().translate(-1, -1, 0);
+
+        int rowCount = endRow - startRow;
+        int localSelectedY = selectedY - rowOffset;
+
         int selectedPosX = selectedX * 20;
-        int selectedPosY = selectedY * 20;
+        int selectedPosY = localSelectedY * 20;
         int endSelectedPosX = selectedPosX + 1;
         int endSelectedPosY = selectedPosY + 1;
 
         boolean firstX = selectedX == 0;
         boolean lastX = selectedX == hotbar.getSizeX() - 1;
-        boolean firstY = selectedY == 0;
-        boolean lastY = selectedY == hotbar.getSizeY() - 1;
+        boolean firstY = localSelectedY == 0;
+        boolean lastY = localSelectedY == rowCount - 1;
 
         // top, bottom, left, right
         if (firstY) {

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/BooleanButton.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/BooleanButton.java
@@ -1,9 +1,9 @@
 package ing.boykiss.inventoryoverhaul.client.gui.widget.config;
 
+import ing.boykiss.inventoryoverhaul.InventoryOverhaul;
 import ing.boykiss.inventoryoverhaul.client.config.annotations.ConfigOption;
 import net.minecraft.client.gui.components.Button;
 
-// TODO: Untested
 public class BooleanButton implements ConfigButton {
     private final ConfigOption.WidgetSize size;
     private final Button widget;
@@ -11,9 +11,19 @@ public class BooleanButton implements ConfigButton {
     public BooleanButton(WidgetData widgetData) throws IllegalAccessException {
         size = widgetData.configOption().size();
         widget = Button.builder(ConfigWidget.getWidgetText(widgetData.field().getName(), widgetData.field().get(widgetData.clientConfig()).toString()), (b) -> {
+            try {
+                boolean currentValue = (boolean) widgetData.field().get(widgetData.clientConfig());
+                boolean newValue = !currentValue;
 
+                widgetData.field().set(widgetData.clientConfig(), newValue);
+
+                widgetData.clientConfig().save();
+
+                b.setMessage(ConfigWidget.getWidgetText(widgetData.field().getName(), Boolean.toString(newValue)));
+            } catch (IllegalAccessException e) {
+                InventoryOverhaul.LOGGER.error(e.getMessage());
+            }
         }).width(widgetData.configOption().size().getSize()).build();
-        // TODO
     }
 
     @Override

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/BooleanCheckbox.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/BooleanCheckbox.java
@@ -1,18 +1,30 @@
 package ing.boykiss.inventoryoverhaul.client.gui.widget.config;
 
+import ing.boykiss.inventoryoverhaul.InventoryOverhaul;
 import ing.boykiss.inventoryoverhaul.client.config.annotations.ConfigOption;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.Checkbox;
 
-// TODO: Untested
 public class BooleanCheckbox implements ConfigCheckbox {
     private final ConfigOption.WidgetSize size;
     private final Checkbox widget;
 
     public BooleanCheckbox(WidgetData widgetData) throws IllegalAccessException {
         size = widgetData.configOption().size();
-        widget = Checkbox.builder(ConfigWidget.getWidgetText(widgetData.field().getName(), widgetData.field().get(widgetData.clientConfig()).toString()), Minecraft.getInstance().font).maxWidth(widgetData.configOption().size().getSize()).build();
-        // TODO
+        boolean currentValue = (boolean) widgetData.field().get(widgetData.clientConfig());
+        widget = Checkbox.builder(ConfigWidget.getWidgetText(widgetData.field().getName()), Minecraft.getInstance().font)
+                .selected(currentValue)
+                .maxWidth(widgetData.configOption().size().getSize())
+                .onValueChange((checkbox, selected) -> {
+                    try {
+                        widgetData.field().set(widgetData.clientConfig(), selected);
+
+                        widgetData.clientConfig().save();
+                    } catch (IllegalAccessException e) {
+                        InventoryOverhaul.LOGGER.error(e.getMessage());
+                    }
+                })
+                .build();
     }
 
     @Override

--- a/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/NumericInput.java
+++ b/common/src/main/java/ing/boykiss/inventoryoverhaul/client/gui/widget/config/NumericInput.java
@@ -1,10 +1,10 @@
 package ing.boykiss.inventoryoverhaul.client.gui.widget.config;
 
+import ing.boykiss.inventoryoverhaul.InventoryOverhaul;
 import ing.boykiss.inventoryoverhaul.client.config.annotations.ConfigOption;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.EditBox;
 
-// TODO: Untested
 public class NumericInput implements ConfigInput {
     private final ConfigOption.WidgetSize size;
     private final EditBox widget;
@@ -12,15 +12,50 @@ public class NumericInput implements ConfigInput {
     public NumericInput(WidgetData widgetData, double min, double max) throws IllegalAccessException {
         size = widgetData.configOption().size();
         double value = Double.parseDouble(widgetData.field().get(widgetData.clientConfig()).toString());
-        widget = new EditBox(Minecraft.getInstance().font, widgetData.configOption().size().getSize(), WIDGET_HEIGHT, ConfigWidget.getWidgetText(widgetData.field().getName()));
-        if (widgetData.type() == short.class || widgetData.type() == Short.class ||
+        boolean isIntegral = widgetData.type() == short.class || widgetData.type() == Short.class ||
                 widgetData.type() == int.class || widgetData.type() == Integer.class ||
-                widgetData.type() == long.class || widgetData.type() == Long.class) {
+                widgetData.type() == long.class || widgetData.type() == Long.class;
+
+        widget = new EditBox(Minecraft.getInstance().font, widgetData.configOption().size().getSize(), WIDGET_HEIGHT, ConfigWidget.getWidgetText(widgetData.field().getName()));
+        if (isIntegral) {
             widget.setValue(Long.toString((long) value));
         } else {
             widget.setValue(Double.toString(value));
         }
-        // TODO
+
+        widget.setResponder((text) -> {
+            try {
+                double parsedValue;
+                try {
+                    parsedValue = Double.parseDouble(text);
+                } catch (NumberFormatException e) {
+                    return;
+                }
+
+                if (!Double.isNaN(min) && parsedValue < min) return;
+                if (!Double.isNaN(max) && parsedValue > max) return;
+
+                if (isIntegral) {
+                    if (widgetData.type() == short.class || widgetData.type() == Short.class) {
+                        widgetData.field().set(widgetData.clientConfig(), (short) parsedValue);
+                    } else if (widgetData.type() == int.class || widgetData.type() == Integer.class) {
+                        widgetData.field().set(widgetData.clientConfig(), (int) parsedValue);
+                    } else {
+                        widgetData.field().set(widgetData.clientConfig(), (long) parsedValue);
+                    }
+                } else {
+                    if (widgetData.type() == float.class || widgetData.type() == Float.class) {
+                        widgetData.field().set(widgetData.clientConfig(), (float) parsedValue);
+                    } else {
+                        widgetData.field().set(widgetData.clientConfig(), parsedValue);
+                    }
+                }
+
+                widgetData.clientConfig().save();
+            } catch (IllegalAccessException e) {
+                InventoryOverhaul.LOGGER.error(e.getMessage());
+            }
+        });
     }
 
     @Override

--- a/common/src/main/resources/assets/inventoryoverhaul/lang/en_us.json
+++ b/common/src/main/resources/assets/inventoryoverhaul/lang/en_us.json
@@ -28,5 +28,11 @@
   "options.hotbarAnchorY.BOTTOM": "Bottom",
   "options.hotbarOffsetY": "Hotbar Vertical Offset",
   "options.hotbarPaddingY": "Hotbar Vertical Padding",
-  "options.hotbarScale": "Hotbar Scale: %s"
+  "options.hotbarScale": "Hotbar Scale: %s",
+  "options.hotbarSplitRows": "Split Hotbar Rows: %s",
+  "options.hotbarSplitRows.true": "On",
+  "options.hotbarSplitRows.false": "Off",
+  "options.hotbarSplitAfterRow": "Split After Row",
+  "options.hotbarSplitGap": "Split Gap (pixels)",
+  "options.hotbarSplitTopOffset": "Top Section Offset"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ java_version=21
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Mod properties
-mod_version=0.0.1-alpha
+mod_version=0.0.2-alpha
 maven_group=ing.boykiss
 archives_name=inventoryoverhaul
 enabled_platforms=fabric,neoforge

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ java_version=21
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 # Mod properties
-mod_version=0.0.2-alpha
+mod_version=0.1.2-alpha
 maven_group=ing.boykiss
 archives_name=inventoryoverhaul
 enabled_platforms=fabric,neoforge


### PR DESCRIPTION
Not sure how useful is this, but I like this mod and I also like survival. I made it optional config to make it split. The item text repositioning, I couldn't figure out at all. Tried a bunch of different ways. Also my fix of the div by zero is on this branch.
- Added some new configs
- Fixed options screen
- New split hotbar functionality

Before and after screenshots:
<img width="3456" height="2168" alt="2026-02-04_13 38 04" src="https://github.com/user-attachments/assets/7f8ed7c3-9a3f-4070-b1b1-67a3c401c0fd" />
<img width="3456" height="2168" alt="2026-02-04_13 39 52" src="https://github.com/user-attachments/assets/cd10630f-5de7-4fee-8df7-0f0c4f1dbbd0" />
